### PR TITLE
Remove citations from core insights

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,6 @@
                             <li><span class='mr-2'>⚠️</span><strong>限制：</strong>缺乏真人溫度，無法評估同理心等軟實力。</li>
                         </ul>
                     </div>`,
-                source: '來源: Arthur Pizzigars / 清邁大學團隊',
                 svg: `
                     <svg viewBox="0 0 400 250" class="w-full h-auto max-w-2xl svg-animate">
                         <defs><clipPath id="circleClip"><circle cx="50" cy="50" r="25"/></clipPath></defs>
@@ -306,7 +305,6 @@
             {
                 title: '遊戲化學習',
                 description: '泰國團隊透過線上密室逃脫、虛擬桌遊等方式，將枯燥的必修課程轉化為有趣的挑戰。學員在合作解謎的過程中，不僅提升了知識吸收效率，更鍛鍊了團隊合作與臨床決策能力。數據證實，此方法成功將國考失敗率從 35% 降至 22%，顯示出遊戲化在驅動學習動機與成效上的巨大潛力。',
-                source: '來源: Cindy Lee / 泰國團隊',
                 svg: `
                     <svg viewBox="0 0 400 250" class="w-full h-auto max-w-2xl svg-animate">
                         <!-- Teacher designing game -->
@@ -338,7 +336,6 @@
             {
                 title: '數據驅動',
                 description: '整合學員的多元數據，從「被動管理」轉向「主動預測與介入」，以數據驅動個人化的教學輔導，並確保評量品質。',
-                source: '來源: Yang Ching-Chian / 清邁大學團隊',
                 svg: `
                     <svg viewBox="0 0 400 250" class="w-full h-auto max-w-2xl svg-animate">
                         <!-- Data Inputs -->
@@ -387,7 +384,6 @@
             {
                 title: '遞迴學習',
                 description: '此概念是 AI 教學的終極目標。AI 系統不僅能根據單一學員的表現調整教學內容（自適應學習），更能從所有學員的互動數據中學習，不斷優化自身的教學策略與教案設計，形成一個能「自我進化」的智慧教學系統。這為實現真正個人化、且能持續迭代的教學系統提供了革命性的藍圖。',
-                source: '來源: Ken Masters',
                 svg: `
                     <svg viewBox="0 0 400 250" class="w-full h-auto max-w-lg svg-animate">
                          <!-- Recursive loop -->
@@ -405,7 +401,6 @@
             {
                 title: '倫理挑戰',
                 description: '大會反覆強調，技術導入前必須先建立倫理框架。例如：當 AI 助教提供錯誤的學習建議時，責任歸屬為何？過度依賴 AI 是否會導致學員核心臨床技能退化？我們該如何界定與 AI 虛擬病人間的互動準則，以維持專業性與同理心？這些都是我們在引進新科技時，必須優先考量與規劃的關鍵課題。',
-                source: '來源: Rakesh Patel / Ken Masters',
                 svg: `
                          <svg viewBox="0 0 400 250" class="w-full h-auto max-w-sm svg-animate">
                             <!-- Scales -->
@@ -438,7 +433,6 @@
                     <div class="w-full md:w-1/2 text-center md:text-left">
                         <h3 class="text-3xl lg:text-4xl font-bold text-slate-700">${insight.title}</h3>
                         <div class="text-slate-600 text-lg lg:text-xl my-4">${insight.description}</div>
-                        <footer class="text-sm text-sky-700 mt-4">${insight.source}</footer>
                     </div>
                 `;
                 carouselContainer.appendChild(slide);


### PR DESCRIPTION
## Summary
- remove source attribution strings from each core insight definition
- stop rendering source footers in the carousel slides

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d6aa48808326a515fbbd0d3baf9a